### PR TITLE
Promise then method is not callable. Can remove the parenthesis.

### DIFF
--- a/JS_Notes/JS-9 Async Await.md
+++ b/JS_Notes/JS-9 Async Await.md
@@ -357,7 +357,7 @@ function resolveAfterNSeconds(n, x) {
     let q = resolveAfterNSeconds(1000, 5);
     // Output, total time
     console.log(x + y + z + await p + await q);
-  })();
+  });
 })();
 ```
 


### PR DESCRIPTION
Because of this, it is giving an error.